### PR TITLE
Fix potential NullPointerException in passenger packet sending and NoSuchElementException in location-drift command

### DIFF
--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
@@ -455,7 +455,8 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
         }
         WrapperPlayServerSetPassengers packet = new WrapperPlayServerSetPassengers(vehicle, passengers.toIntArray());
         Object channel = PacketEvents.getAPI().getProtocolManager().getChannel(playerData.getPlayerUUID());
-        PacketEvents.getAPI().getProtocolManager().getUser(channel).writePacketSilently(packet);
+        User user = channel == null ? null : PacketEvents.getAPI().getProtocolManager().getUser(channel);
+        COMMON.writeIfPresent(user, packet);
     }
 
     private PacketEventsEntity trackEntitySpawn(PlayerData playerData, UUID entityUUID, int entityID, UUID world, double x, double y, double z, EntityType entityType) {

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/commands/RaycastedAntiESPCommand.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/commands/RaycastedAntiESPCommand.java
@@ -143,8 +143,9 @@ public class RaycastedAntiESPCommand {
             assert Attribution.READ_COMMENTS_BEFORE_EDITING_OR_DELETING_CLASS_OR_FACE_LEGAL_ACTION == 0; //Using constant from Attribution class to ensure that it cannot be deleted without the developer noticing that they are obligated to replace it with an equivalent notice.
             Player player = (Player) sender;
             PlayerData playerData = PlayerRegistry.getInstance().getPlayerData(player.getUniqueId());
-            Entity closestEntity = player.getNearbyEntities(10,10,10).getFirst();
-            if (closestEntity == null) return;
+            var nearbyEntities = player.getNearbyEntities(10,10,10);
+            if (nearbyEntities.isEmpty()) return;
+            Entity closestEntity = nearbyEntities.getFirst();
             player.sendRichMessage("Closest entity is "+closestEntity.getName());
             Spatial entityPosition = playerData.entityView().getPosition(closestEntity.getUniqueId());
             Location bukkitLoc = closestEntity.getLocation().clone();


### PR DESCRIPTION
1. Prevents a `NoSuchElementException` when executing `/raycastedantiesp test location-drift` without any nearby entities present by checking `isEmpty()` before calling `getFirst()`.
2. Prevents a `NullPointerException` in `sendEntityPassengerPacket` when resolving a disconnected or null PacketEvents `User` channel, delegating packet writing to `COMMON.writeIfPresent`.