### PR TITLE
Drop trailing packets for recently destroyed entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ gradle-app.setting
 .gradletasknamecache
 
 **/build/
+bin/
+**/bin/
 
 # Common working directory
 run*/

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/players/NettyData.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/players/NettyData.java
@@ -275,10 +275,62 @@ public class NettyData implements Clearable {
                 entry.setValue(survivingHead);
             }
         }
+        if (!recentlyDestroyedEntityIDs.isEmpty()) {
+            var it = recentlyDestroyedEntityIDs.int2IntEntrySet().fastIterator();
+            while (it.hasNext()) {
+                var entry = it.next();
+                int age = currentTick - entry.getIntValue();
+                if (age < 0 || age > DESTROYED_ENTITY_EXPIRY_TICKS) {
+                    it.remove();
+                }
+            }
+        }
     }
 
     //
     // END Netty entity spawn task queue.
+    // ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    //
+
+    //
+    // ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    // START Recently destroyed entity tracking:
+    //
+    public static final int DESTROYED_ENTITY_EXPIRY_TICKS = 40;
+    /**
+     * Maps entityID -> tick when destroyed. Used to avoid queuing speculative post-spawn reconciliation
+     * tasks for trailing packets (e.g. position sync, metadata, attributes) arriving after an entity has been untracked/destroyed.
+     */
+    private final Int2IntOpenHashMap recentlyDestroyedEntityIDs = createRecentlyDestroyedMap();
+
+    private static Int2IntOpenHashMap createRecentlyDestroyedMap() {
+        Int2IntOpenHashMap map = new Int2IntOpenHashMap(DEFAULT_MAP_SIZE);
+        map.defaultReturnValue(Integer.MIN_VALUE);
+        return map;
+    }
+
+    public void recordDestroyedEntity(int entityID, int currentTick) {
+        recentlyDestroyedEntityIDs.put(entityID, currentTick);
+    }
+
+    public boolean isRecentlyDestroyed(int entityID, int currentTick) {
+        int destroyedTick = recentlyDestroyedEntityIDs.get(entityID);
+        if (destroyedTick == Integer.MIN_VALUE) {
+            return false;
+        }
+        int age = currentTick - destroyedTick;
+        if (age < 0 || age > DESTROYED_ENTITY_EXPIRY_TICKS) {
+            recentlyDestroyedEntityIDs.remove(entityID);
+            return false;
+        }
+        return true;
+    }
+
+    public void removeDestroyedEntity(int entityID) {
+        recentlyDestroyedEntityIDs.remove(entityID);
+    }
+    //
+    // END Recently destroyed entity tracking.
     // ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //
 
@@ -383,6 +435,7 @@ public class NettyData implements Clearable {
         unresolvedPassengerIDsByVehicleID.clear();
         unresolvedVehicleIDsByPassengerID.clear();
         pendingPostEntitySpawnTasksByEntityID.clear();
+        recentlyDestroyedEntityIDs.clear();
         evictPendingPostSpawnTasksOnNextPacket = false;
     }
 

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/players/PlayerLocatable.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/players/PlayerLocatable.java
@@ -64,6 +64,7 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
     /** Updates the player's foot position while retaining rotation and pose. */
     public void updateFoot(double footX, double footY, double footZ) {
         validateFinite(footX, footY, footZ);
+        validateInitialised();
         synchronized (writerMonitor) {
             X.setOpaque(this, footX);
             Y.setOpaque(this, footY);
@@ -74,6 +75,7 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
     /** Updates the player's rotation while retaining position and pose. */
     public void updateRotation(float yaw, float pitch) {
         validateRotation(yaw, pitch);
+        validateInitialised();
         synchronized (writerMonitor) {
             YAW.setOpaque(this, yaw);
             PITCH.setOpaque(this, pitch);
@@ -83,6 +85,7 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
     /** Updates the player's pose while retaining position and rotation. */
     public void updatePose(PlayerPose pose) {
         Objects.requireNonNull(pose, "pose");
+        validateInitialised();
         synchronized (writerMonitor) {
             POSE.setOpaque(this, pose);
         }
@@ -92,6 +95,7 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
     public void updateFootAndRotation(double footX, double footY, double footZ, float yaw, float pitch) {
         validateFinite(footX, footY, footZ);
         validateRotation(yaw, pitch);
+        validateInitialised();
         synchronized (writerMonitor) {
             X.setOpaque(this, footX);
             Y.setOpaque(this, footY);
@@ -230,6 +234,7 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
             invalidate();
             return this;
         }
+        validateInitialised();
         synchronized (writerMonitor) {
             WORLD.setOpaque(this, world);
             return this;
@@ -344,6 +349,12 @@ public final class PlayerLocatable implements MutableFloatingLocatable, Floating
     private static void validateFinite(double value) {
         if (!Double.isFinite(value)) {
             throw new IllegalArgumentException("Coordinate must be finite");
+        }
+    }
+
+    private void validateInitialised() {
+        if (world() == null || pose() == null) {
+            throw new IllegalStateException("PlayerLocatable has not been initialized");
         }
     }
 

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/EntitySpawnTask.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/EntitySpawnTask.java
@@ -41,14 +41,9 @@ public interface EntitySpawnTask extends Runnable {
     default EntitySpawnTask trimExpiredTasks(int currentTick) {
         EntitySpawnTask current = this;
         while (current != null && current.thisShouldBeEvicted(currentTick)) {
-            Logger.warning("A task was evicted from the Netty task queue due to being too old! This should not happen under normal circumstances and may indicate a problem with the system being overloaded or tasks taking too long to execute. Current tick=" + currentTick + " Task=" + current, 3, EntitySpawnTask.class);
+            Logger.warning("A task was evicted from the Netty task queue due to being too old! Current tick=" + currentTick + " Task=" + current, 6, EntitySpawnTask.class);
             EntitySpawnTask next = current.getNext();
             current.setNext(null);
-            try {
-                current.run(); // perhaps the task is salvageable even if we missed the correct caller
-            } catch (Exception e) {
-                Logger.error("Error while running evicted future netty task " + current, e, 3, EntitySpawnTask.class);
-            }
             current = next;
         }
         return current;

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
@@ -78,6 +78,11 @@ public abstract class PacketEntityViewController<P> {
                 playerData.entityView().clear();
                 playerData.playerView().clear();
                 nettyData.clearPendingReconciliationState();
+                if (remainingEntityIDs != null) {
+                    for (int id : remainingEntityIDs) {
+                        nettyData.recordDestroyedEntity(id, currentTick);
+                    }
+                }
                 nettyData.getSelfEntity().clear();
             }
             nettyData.setCurrentWorldName(world).setCurrentWorldMinHeight(minWorldHeight);
@@ -108,6 +113,7 @@ public abstract class PacketEntityViewController<P> {
      */
     @Packet(Packet.Packets.SPAWN_ENTITY)
     protected boolean handleEntitySpawn(P packet, int entityID, boolean isPlayer, PlayerData playerData, UUID world, int currentTick) {
+        playerData.nettyData().removeDestroyedEntity(entityID);
         boolean returnValue = handleEntitySpawn0(packet, isPlayer, playerData, world, currentTick);
         playerData.nettyData().runPendingPostSpawnTaskForEntity(entityID);
         return returnValue;
@@ -377,6 +383,7 @@ public abstract class PacketEntityViewController<P> {
 
     protected void handleDestroyEntities(int[] entityIDs, PlayerData playerData, int currentTick) {
         for (int entityID : entityIDs) {
+            playerData.nettyData().recordDestroyedEntity(entityID, currentTick);
             if (playerData.nettyData().consumeExpectedWorldTransitionDestroyEntityID(entityID)) {
                 playerData.nettyData().clearPendingPostSpawnTasksForEntity(entityID);
                 playerData.entityView().removeEntity(entityID);
@@ -662,6 +669,7 @@ public abstract class PacketEntityViewController<P> {
      * to own the authoritative relationship state.
      */
     protected void handleBypassedEntitySpawn(int entityID, PlayerData playerData, int currentTick) {
+        playerData.nettyData().removeDestroyedEntity(entityID);
         // Vanilla may send entity state before its spawn packet, and those packets were already
         // forwarded to the client. Discard deferred tracking work rather than replaying duplicates.
         playerData.nettyData().clearPendingPostSpawnTasksForEntity(entityID);

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtilTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtilTest.java
@@ -31,7 +31,7 @@ class RaycastUtilTest {
         Locatable start = new ImmutableLocatableImpl(world, 0, 0, 0);
         RecordingParticleSpawner particles = new RecordingParticleSpawner();
 
-        assertTrue(RaycastUtil.raycast(start, new ImmutableSpatialImpl(2, 0, 0), 1, 0, 10, true, emptyBlockView(), 1, particles));
+        assertTrue(RaycastUtil.raycastUnrolledAccumulated(1, 0, 10, true, 0f, emptyBlockView(), start, new ImmutableSpatialImpl(2, 0, 0), particles));
         assertEquals(List.of(world), particles.worlds);
     }
 
@@ -41,7 +41,7 @@ class RaycastUtilTest {
         Locatable start = new ImmutableLocatableImpl(world, 0.5, 0.5, 0.5);
         RecordingParticleSpawner particles = new RecordingParticleSpawner();
 
-        assertTrue(RaycastUtil.raycast(start, new ImmutableBlockSpatialImpl(3, 0, 0), 1, 0, 10, true, emptyBlockView(), 1, particles));
+        assertTrue(RaycastUtil.raycastUnrolledAccumulated(1, 0, 10, true, 0f, emptyBlockView(), start, new ImmutableBlockSpatialImpl(3, 0, 0), particles));
         assertEquals(0.5, particles.positions.getFirst().y());
         assertEquals(0.5, particles.positions.getFirst().z());
     }
@@ -65,8 +65,13 @@ class RaycastUtilTest {
 
         @Override
         public void spawnParticleAt(UUID world, Spatial spatial, Colour colour) {
+            spawnParticleAt(world, spatial.x(), spatial.y(), spatial.z(), colour);
+        }
+
+        @Override
+        public void spawnParticleAt(UUID world, double x, double y, double z, Colour colour) {
             worlds.add(world);
-            positions.add(new ImmutableSpatialImpl(spatial.x(), spatial.y(), spatial.z()));
+            positions.add(new ImmutableSpatialImpl(x, y, z));
         }
     }
 }

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PECacheablePacketReconciliationTask.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PECacheablePacketReconciliationTask.java
@@ -33,7 +33,7 @@ final class PECacheablePacketReconciliationTask extends BaseEntitySpawnTask {
     public void run() {
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
-            Logger.error("Reconciliation fail: Attempted to cache packet for unknown entity, id=" + entityID + " packet=" + packet.getClass().getSimpleName() + ".", 3, this.getClass());
+            Logger.warning("Reconciliation fail: Attempted to cache packet for unknown entity, id=" + entityID + " packet=" + packet.getClass().getSimpleName() + ".", 6, this.getClass());
             if (packet instanceof WrapperPlayServerEntityMetadata metadataPacket) {
                 var data = metadataPacket.getEntityMetadata();
                 for (EntityData<?> eData : data) {

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
@@ -338,6 +338,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received relative move packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.relativeMove(
                     playerData, entityID, packet.getDeltaX(), packet.getDeltaY(), packet.getDeltaZ(), packet.isOnGround(), currentTick));
@@ -355,6 +358,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received relative move and rotation packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.relativeMoveAndRotation(
                     playerData, entityID, packetWrapper.getDeltaX(), packetWrapper.getDeltaY(), packetWrapper.getDeltaZ(),
@@ -376,6 +382,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
         Vector3d velocity = packetWrapper.getDeltaMovement();
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received teleport packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.teleport(
                     playerData, entityID, position.getX(), position.getY(), position.getZ(), packetWrapper.getYaw(), packetWrapper.getPitch(),
@@ -398,6 +407,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
         Vector3d velocity = values.getDeltaMovement();
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received position sync packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.positionSync(
                     playerData, entityID, position.getX(), position.getY(), position.getZ(), values.getYaw(), values.getPitch(),
@@ -476,6 +488,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
         }
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return;
+            }
             Logger.warning("Attempted to cache packet for unknown entity, id=" + entityID + " packet=" + packet.getClass().getSimpleName() + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, new PECacheablePacketReconciliationTask(playerData, entityID, packet, currentTick));
             return;
@@ -490,6 +505,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received rotation packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.rotation(
                     playerData, entityID, packetWrapper.getYaw(), packetWrapper.getPitch(), packetWrapper.isOnGround(), currentTick));
@@ -507,6 +525,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received head look packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.headLook(
                     playerData, entityID, packetWrapper.getHeadYaw(), currentTick));
@@ -524,6 +545,9 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
         NettyEntity<?> entity = playerData.entityFromID(entityID);
         if (entity == null) {
+            if (playerData.nettyData().isRecentlyDestroyed(entityID, currentTick)) {
+                return entityID;
+            }
             Logger.warning("Received velocity packet for unknown entity, id=" + entityID + ". Queuing retry.", 6, PacketEventsEntityViewController.class);
             playerData.nettyData().addPostEntitySpawnTask(entityID, PEEntityStateReconciliationTask.velocity(
                     playerData, entityID, packetWrapper.getVelocity().getX(), packetWrapper.getVelocity().getY(), packetWrapper.getVelocity().getZ(), currentTick));

--- a/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PEEntityStateReconciliationTaskTest.java
+++ b/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PEEntityStateReconciliationTaskTest.java
@@ -24,8 +24,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import games.cubi.raycastedantiesp.core.players.NettyData;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PEEntityStateReconciliationTaskTest {
     private static final UUID WORLD = UUID.randomUUID();
@@ -126,6 +130,56 @@ class PEEntityStateReconciliationTaskTest {
         playerData.nettyData().evictOldPendingPostSpawnTasks(EntitySpawnTask.TICKS_BEFORE_EVICTION);
 
         assertNull(playerData.nettyData().consumePendingPostSpawnTasksForEntity(entityID));
+    }
+
+    @Test
+    void recentlyDestroyedEntitySuppressesReconciliationQueuing() {
+        PlayerData playerData = playerData();
+        int entityID = 99;
+        int destroyedTick = 100;
+
+        playerData.nettyData().recordDestroyedEntity(entityID, destroyedTick);
+        assertTrue(playerData.nettyData().isRecentlyDestroyed(entityID, destroyedTick + 5));
+
+        // When recently destroyed, no tasks should be queued for this entity
+        assertNull(playerData.nettyData().consumePendingPostSpawnTasksForEntity(entityID));
+    }
+
+    @Test
+    void recentlyDestroyedEntityExpiresAfterConfiguredTicks() {
+        PlayerData playerData = playerData();
+        int entityID = 101;
+        int destroyedTick = 10;
+
+        playerData.nettyData().recordDestroyedEntity(entityID, destroyedTick);
+        assertTrue(playerData.nettyData().isRecentlyDestroyed(entityID, destroyedTick + 10));
+        assertTrue(playerData.nettyData().isRecentlyDestroyed(entityID, destroyedTick + NettyData.DESTROYED_ENTITY_EXPIRY_TICKS));
+        assertFalse(playerData.nettyData().isRecentlyDestroyed(entityID, destroyedTick + NettyData.DESTROYED_ENTITY_EXPIRY_TICKS + 1));
+    }
+
+    @Test
+    void respawnClearsRecentlyDestroyedState() {
+        PlayerData playerData = playerData();
+        int entityID = 102;
+        int currentTick = 50;
+
+        playerData.nettyData().recordDestroyedEntity(entityID, currentTick);
+        assertTrue(playerData.nettyData().isRecentlyDestroyed(entityID, currentTick));
+
+        playerData.nettyData().removeDestroyedEntity(entityID);
+        assertFalse(playerData.nettyData().isRecentlyDestroyed(entityID, currentTick));
+    }
+
+    @Test
+    void evictOldPendingPostSpawnTasksPrunesExpiredDestroyedEntities() {
+        PlayerData playerData = playerData();
+        int entityID = 103;
+        int currentTick = 100;
+
+        playerData.nettyData().recordDestroyedEntity(entityID, currentTick);
+        playerData.nettyData().evictOldPendingPostSpawnTasks(currentTick + NettyData.DESTROYED_ENTITY_EXPIRY_TICKS + 5);
+
+        assertFalse(playerData.nettyData().isRecentlyDestroyed(entityID, currentTick + NettyData.DESTROYED_ENTITY_EXPIRY_TICKS + 5));
     }
 
     private PlayerData playerData() {


### PR DESCRIPTION
### Summary of Changes

Fixes console warnings (`EntitySpawnTask: A task was evicted from the Netty task queue due to being too old!`) and reconciliation failure errors occurring on servers running multithreaded entity trackers (such as Leaf).

#### Problem
In multithreaded tracking architectures, trailing entity packets (position sync, metadata, attributes, relative movement, rotation, head look) can arrive at the Netty channel shortly after an entity has already been untracked and destroyed (`ClientboundRemoveEntitiesPacket`). RaycastedAntiESP assumed any packet for an unknown entity was an out-of-order packet preceding a future `SPAWN_ENTITY` packet, queueing it into deferred reconciliation tasks. Because the entity was destroyed, the spawn packet never arrived, triggering a task eviction warning 16 ticks later and a subsequent failed reconciliation execution.

#### Solution
- **Recently Destroyed Registry:** Added a sliding window (`DESTROYED_ENTITY_EXPIRY_TICKS = 40`) in `NettyData` to record recently destroyed entity IDs for each player connection.
- **Fast-Path Drop:** In `PacketEventsEntityViewController`, dropped trailing packets immediately if `isRecentlyDestroyed(entityID, currentTick)` is true, avoiding unnecessary task allocations and queueing.
- **Lifecycle Cleanup:** Destroyed IDs are recorded during `handleDestroyEntities` and world transitions, and cleared upon entity ID reuse or spawn.
- **Eviction Safety:** Demoted task eviction warning log level from 3 to 6 (debug) and prevented running evicted tasks on missing entities. Demoted `PECacheablePacketReconciliationTask` unknown entity log to debug level 6 to match `PEEntityStateReconciliationTask`.
- **Test Fixes & Coverage:** Updated `RaycastUtilTest` and `PlayerLocatable` to pass upstream test suites, and added unit tests in `PEEntityStateReconciliationTaskTest` covering the destroyed entity lifecycle.
